### PR TITLE
Fix typo: msg --> mag

### DIFF
--- a/witmotion/__init__.py
+++ b/witmotion/__init__.py
@@ -130,7 +130,7 @@ class IMU:
             self.last_pitch = msg.pitch
             self.last_yaw = msg.yaw
         elif isinstance(msg, MagneticMessage):
-            self.last_msg = msg.mag
+            self.last_mag = msg.mag
             self.last_temp_celsius = msg.temp_celsius
         elif isinstance(msg, QuaternionMessage):
             self.last_q = msg.q


### PR DESCRIPTION
I assume you meant mag here, not msg. IMU.last_mag and IMU.get_magnetic_vector() don't work on my BWT901CL, which led me to notice this.